### PR TITLE
implement better file locking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "venvcache"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "fd-lock",
+ "libc",
  "log",
  "pretty_env_logger",
  "rusqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,16 +210,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,17 +220,6 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
-name = "fd-lock"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
-dependencies = [
- "cfg-if",
- "rustix",
- "windows-sys",
-]
 
 [[package]]
 name = "fuchsia-cprng"
@@ -378,12 +357,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "log"
@@ -561,19 +534,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.38.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
-dependencies = [
- "bitflags 2.5.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,26 +643,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.58",
-]
-
-[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,7 +684,6 @@ version = "0.1.2"
 dependencies = [
  "anyhow",
  "chrono",
- "fd-lock",
  "libc",
  "log",
  "pretty_env_logger",
@@ -752,7 +691,6 @@ dependencies = [
  "sha256",
  "structopt",
  "tempdir",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "venvcache"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 anyhow = "1.0.81"
 chrono = "0.4.31"
 fd-lock = "4.0.2"
+libc = "0.2.153"
 log = "0.4.21"
 pretty_env_logger = "0.5.0"
 rusqlite = { version = "0.31.0", features = ["bundled", "chrono"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ pretty_env_logger = "0.5.0"
 rusqlite = { version = "0.31.0", features = ["bundled", "chrono"] }
 sha256 = { version = "1.5.0", default-features = false }
 structopt = "0.3.26"
-thiserror = "1.0.58"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.81"
 chrono = "0.4.31"
-fd-lock = "4.0.2"
 libc = "0.2.153"
 log = "0.4.21"
 pretty_env_logger = "0.5.0"

--- a/src/file_lock.rs
+++ b/src/file_lock.rs
@@ -18,11 +18,11 @@ impl FileLock {
         Ok(Self { file })
     }
 
-    pub fn read_lock(&mut self) -> anyhow::Result<ReadLock> {
+    pub fn read(&mut self) -> anyhow::Result<ReadLock> {
         ReadLock::new(&mut self.file)
     }
 
-    pub fn write_lock(&mut self) -> anyhow::Result<WriteLock> {
+    pub fn write(&mut self) -> anyhow::Result<WriteLock> {
         WriteLock::new(&mut self.file)
     }
 }

--- a/src/file_lock.rs
+++ b/src/file_lock.rs
@@ -46,7 +46,8 @@ impl<'a> ReadLock<'a> {
 impl Drop for ReadLock<'_> {
     fn drop(&mut self) {
         if let Some(ref mut file) = self.file {
-            apply_lock(file, LockOperation::Unlock).expect("Failed to unlock file during ReadLock Drop");
+            apply_lock(file, LockOperation::Unlock)
+                .expect("Failed to unlock file during ReadLock Drop");
         }
     }
 }
@@ -70,7 +71,8 @@ impl<'a> WriteLock<'a> {
 impl Drop for WriteLock<'_> {
     fn drop(&mut self) {
         if let Some(ref mut file) = self.file {
-            apply_lock(file, LockOperation::Unlock).expect("Failed to unlock file during WriteLock Drop");
+            apply_lock(file, LockOperation::Unlock)
+                .expect("Failed to unlock file during WriteLock Drop");
         }
     }
 }
@@ -93,7 +95,7 @@ fn apply_lock(file: &mut File, operation: LockOperation) -> anyhow::Result<()> {
             fd,
             F_SETLKW,
             &flock {
-                l_type: lock_type as i16,
+                l_type: lock_type,
                 l_whence: libc::SEEK_SET as i16,
                 l_start: 0,
                 l_len: 0,

--- a/src/file_lock.rs
+++ b/src/file_lock.rs
@@ -1,0 +1,50 @@
+/// Provides a file locking interface for files on POSIX-compliant operating systems.
+/// Very similar to the open source fd-lock library,
+/// except that it supports atomically upgrading / downgrading the lock.
+use std::fs::File;
+
+pub struct FileLock {
+    file: File,
+}
+
+impl FileLock {
+    pub fn new() -> anyhow::Result<Self> {
+        todo!()
+    }
+
+    pub fn read_lock(&mut self) -> anyhow::Result<ReadLock> {
+        todo!()
+    }
+
+    pub fn write_lock(&mut self) -> anyhow::Result<WriteLock> {
+        todo!()
+    }
+}
+
+pub struct ReadLock<'a> {
+    file: &'a mut File,
+}
+
+impl<'a> ReadLock<'a> {
+    pub fn upgrade(self) -> WriteLock<'a> {
+        todo!()
+    }
+}
+
+impl Drop for ReadLock<'_> {
+    fn drop(&mut self) {}
+}
+
+pub struct WriteLock<'a> {
+    file: &'a mut File,
+}
+
+impl<'a> WriteLock<'a> {
+    pub fn downgrade(self) -> ReadLock<'a> {
+        todo!()
+    }
+}
+
+impl Drop for WriteLock<'_> {
+    fn drop(&mut self) {}
+}

--- a/src/file_lock.rs
+++ b/src/file_lock.rs
@@ -1,50 +1,108 @@
-/// Provides a file locking interface for files on POSIX-compliant operating systems.
-/// Very similar to the open source fd-lock library,
-/// except that it supports atomically upgrading / downgrading the lock.
+//! Provides a file locking interface for files on POSIX-compliant operating systems.
+//! Very similar to the open source fd-lock library,
+//! except that it supports atomically upgrading / downgrading the lock.
+use libc::fcntl;
+use libc::flock;
+use libc::F_SETLKW;
 use std::fs::File;
+use std::os::unix::io::AsRawFd;
+use std::path::Path;
 
 pub struct FileLock {
     file: File,
 }
 
 impl FileLock {
-    pub fn new() -> anyhow::Result<Self> {
-        todo!()
+    pub fn new(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        let file = File::create(path)?;
+        Ok(Self { file })
     }
 
     pub fn read_lock(&mut self) -> anyhow::Result<ReadLock> {
-        todo!()
+        ReadLock::new(&mut self.file)
     }
 
     pub fn write_lock(&mut self) -> anyhow::Result<WriteLock> {
-        todo!()
+        WriteLock::new(&mut self.file)
     }
 }
 
 pub struct ReadLock<'a> {
-    file: &'a mut File,
+    file: Option<&'a mut File>,
 }
 
 impl<'a> ReadLock<'a> {
-    pub fn upgrade(self) -> WriteLock<'a> {
-        todo!()
+    fn new(file: &'a mut File) -> anyhow::Result<Self> {
+        apply_lock(file, LockOperation::Read)?;
+        Ok(Self { file: Some(file) })
+    }
+
+    pub fn upgrade(mut self) -> anyhow::Result<WriteLock<'a>> {
+        let file = self.file.take().unwrap();
+        WriteLock::new(file)
     }
 }
 
 impl Drop for ReadLock<'_> {
-    fn drop(&mut self) {}
+    fn drop(&mut self) {
+        if let Some(ref mut file) = self.file {
+            apply_lock(file, LockOperation::Unlock).expect("Failed to unlock file during ReadLock Drop");
+        }
+    }
 }
 
 pub struct WriteLock<'a> {
-    file: &'a mut File,
+    file: Option<&'a mut File>,
 }
 
 impl<'a> WriteLock<'a> {
-    pub fn downgrade(self) -> ReadLock<'a> {
-        todo!()
+    fn new(file: &'a mut File) -> anyhow::Result<Self> {
+        apply_lock(file, LockOperation::Write)?;
+        Ok(Self { file: Some(file) })
+    }
+
+    pub fn downgrade(mut self) -> anyhow::Result<ReadLock<'a>> {
+        let file = self.file.take().unwrap();
+        ReadLock::new(file)
     }
 }
 
 impl Drop for WriteLock<'_> {
-    fn drop(&mut self) {}
+    fn drop(&mut self) {
+        if let Some(ref mut file) = self.file {
+            apply_lock(file, LockOperation::Unlock).expect("Failed to unlock file during WriteLock Drop");
+        }
+    }
+}
+
+enum LockOperation {
+    Read,
+    Write,
+    Unlock,
+}
+
+fn apply_lock(file: &mut File, operation: LockOperation) -> anyhow::Result<()> {
+    let fd = file.as_raw_fd();
+    let lock_type = match operation {
+        LockOperation::Read => libc::F_RDLCK,
+        LockOperation::Write => libc::F_WRLCK,
+        LockOperation::Unlock => libc::F_UNLCK,
+    };
+    let result = unsafe {
+        fcntl(
+            fd,
+            F_SETLKW,
+            &flock {
+                l_type: lock_type as i16,
+                l_whence: libc::SEEK_SET as i16,
+                l_start: 0,
+                l_len: 0,
+                l_pid: 0,
+            },
+        )
+    };
+    if result == -1 {
+        anyhow::bail!("Failed to lock file");
+    }
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use structopt::StructOpt;
 
 use crate::journal::Journal;
 
+mod file_lock;
 mod journal;
 mod venv;
 

--- a/src/venv.rs
+++ b/src/venv.rs
@@ -47,7 +47,13 @@ impl VenvManager {
     pub fn delete(&mut self) -> anyhow::Result<()> {
         log::debug!("Deleting virtual environment at {:?}", self.path);
         let _write_lock = self.lock.write()?;
-        std::fs::remove_dir_all(&self.path)?;
+        let result = std::fs::remove_dir_all(&self.path);
+        if let Err(err) = result {
+            if err.kind() == std::io::ErrorKind::NotFound {
+                return Ok(());
+            }
+            return Err(err.into())
+        }
         Ok(())
     }
 }

--- a/src/venv.rs
+++ b/src/venv.rs
@@ -1,17 +1,11 @@
 use crate::file_lock::FileLock;
+use crate::file_lock::ReadLock;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 use std::process::ExitStatus;
-use thiserror::Error;
-
-#[derive(Debug, Error, Eq, PartialEq)]
-pub enum Error {
-    #[error("The requested venv didn't exist when we attempted to execute something using it.")]
-    MissingVenv,
-}
 
 pub struct VenvManager {
     path: PathBuf,
@@ -27,55 +21,18 @@ impl VenvManager {
         })
     }
 
-    pub fn create(&mut self, python_executable: &Path, requirements: &str) -> anyhow::Result<()> {
-        log::debug!("Creating virtual environment at {:?}", self.path);
-        let _write_lock = self.lock.write()?;
-
-        if self.path.join("bin").join("python").exists() {
-            log::debug!("Virtual environment already exists at {:?}", self.path);
-            return Ok(());
-        }
-
-        std::fs::create_dir_all(&self.path)?;
-        let status = Command::new(python_executable)
-            .args(["-m", "venv"])
-            .arg(&self.path)
-            .status()?;
-        anyhow::ensure!(status.success(), "Failed to create virtual environment");
-
-        let requirements_file_path = self.path.with_extension("requirements");
-        {
-            let mut requirements_file = File::create(&requirements_file_path)?;
-            requirements_file.write_all(requirements.as_bytes())?;
-        }
-
-        let venv_pip = self.path.join("bin").join("pip");
-        let status = Command::new(&venv_pip)
-            .args(&["install", "-r"])
-            .arg(requirements_file_path)
-            .status()?;
-        anyhow::ensure!(
-            status.success(),
-            "Failed to pip install requirements into virtual environment"
-        );
-
-        Ok(())
-    }
-
-    pub fn delete(&mut self) -> anyhow::Result<()> {
-        log::debug!("Deleting virtual environment at {:?}", self.path);
-        let _write_lock = self.lock.write()?;
-        std::fs::remove_dir_all(&self.path)?;
-        Ok(())
-    }
-
-    pub fn run(&mut self, args: &[String]) -> anyhow::Result<ExitStatus> {
+    pub fn run(
+        &mut self,
+        python_executable: &Path,
+        requirements: &str,
+        args: &[String],
+    ) -> anyhow::Result<ExitStatus> {
         log::debug!("Running Python in virtual environment at {:?}", self.path);
-        let _read_lock = self.lock.read()?;
+        let mut _read_lock = self.lock.read()?;
 
         let venv_python = self.path.join("bin").join("python");
         if !venv_python.exists() {
-            return Err(Error::MissingVenv.into());
+            _read_lock = create_venv(_read_lock, python_executable, requirements, &self.path)?;
         }
 
         let status = match Command::new(venv_python).args(args).status() {
@@ -86,6 +43,13 @@ impl VenvManager {
         };
         Ok(status)
     }
+
+    pub fn delete(&mut self) -> anyhow::Result<()> {
+        log::debug!("Deleting virtual environment at {:?}", self.path);
+        let _write_lock = self.lock.write()?;
+        std::fs::remove_dir_all(&self.path)?;
+        Ok(())
+    }
 }
 
 pub fn venv_sha(python_executable: &Path, requirements: &str) -> anyhow::Result<String> {
@@ -93,6 +57,47 @@ pub fn venv_sha(python_executable: &Path, requirements: &str) -> anyhow::Result<
     Ok(sha256::digest(format!(
         "{python_version}\n\n{requirements}"
     )))
+}
+
+fn create_venv<'a>(
+    read_lock: ReadLock<'a>,
+    python_executable: &Path,
+    requirements: &str,
+    venv_path: &Path,
+) -> anyhow::Result<ReadLock<'a>> {
+    let write_lock = read_lock.upgrade()?;
+
+    if venv_path.join("bin").join("python").exists() {
+        panic!(
+            "Virtual environment already exists at {:?}. This function shouldn't have been called.",
+            venv_path
+        );
+    }
+
+    std::fs::create_dir_all(venv_path)?;
+    let status = Command::new(python_executable)
+        .args(["-m", "venv"])
+        .arg(venv_path)
+        .status()?;
+    anyhow::ensure!(status.success(), "Failed to create virtual environment");
+
+    let requirements_file_path = venv_path.with_extension("requirements");
+    {
+        let mut requirements_file = File::create(&requirements_file_path)?;
+        requirements_file.write_all(requirements.as_bytes())?;
+    }
+
+    let venv_pip = venv_path.join("bin").join("pip");
+    let status = Command::new(venv_pip)
+        .args(["install", "-r"])
+        .arg(requirements_file_path)
+        .status()?;
+    anyhow::ensure!(
+        status.success(),
+        "Failed to pip install requirements into virtual environment"
+    );
+
+    write_lock.downgrade()
 }
 
 fn python_version(python_executable: &Path) -> anyhow::Result<String> {

--- a/src/venv.rs
+++ b/src/venv.rs
@@ -1,3 +1,4 @@
+use crate::file_lock::FileLock;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
@@ -14,7 +15,7 @@ pub enum Error {
 
 pub struct VenvManager {
     path: PathBuf,
-    lock: fd_lock::RwLock<File>,
+    lock: FileLock,
 }
 
 impl VenvManager {
@@ -22,7 +23,7 @@ impl VenvManager {
         let lock_path = path.with_extension("lock");
         Ok(Self {
             path,
-            lock: fd_lock::RwLock::new(File::create(lock_path)?),
+            lock: FileLock::new(lock_path)?,
         })
     }
 
@@ -68,7 +69,7 @@ impl VenvManager {
         Ok(())
     }
 
-    pub fn run(&self, args: &[String]) -> anyhow::Result<ExitStatus> {
+    pub fn run(&mut self, args: &[String]) -> anyhow::Result<ExitStatus> {
         log::debug!("Running Python in virtual environment at {:?}", self.path);
         let _read_lock = self.lock.read()?;
 


### PR DESCRIPTION
Before we were using `fd-lock` which, probably because of it being designed for cross-platform use, does not allow you to atomically upgrade/downgrade file locks between read-only and read-write. The syscall `fcntl` _does_ let you atomically upgrade/downgrade these locks:

> A single process can hold only one type of lock on a file region; if a new lock is applied to an already-locked region, then the existing lock is converted to the new lock type.

So I've re-implemented a file locking interface using `fcntl` directly to let us have atomicity here. This program is designed to work only on posix systems anyways, so :shrug:!