### PR TITLE
support receiving requirements directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "venvcache"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "venvcache"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Moves the current `--requirements` flag to be `--requirements-path` (for files on disk) and adds a new argument `--requirements` which corresponds to receiving requirements from the command line. This can also be passed in as `VENVCACHE_REQUIREMENTS`.

The idea here is that some CI systems (e.g. Buildkite) let you set environment variables, so this provides a mechanism to run Python like:

```yaml
- label: Whatever
  id: whatever
  command: venvcache -- -m path.to.module
  env:
    VENVCACHE_REQUIREMENTS: |
      requests==1.2.3
```